### PR TITLE
adds test for minimongo post endpoint

### DIFF
--- a/test_cases.py
+++ b/test_cases.py
@@ -1,7 +1,9 @@
 import requests
+import json
 
 def test_retrobiohub_endpoint(url):
-    ''' Test the /retrobiohub post endpoint '''
+    """ Test the /retrobiohub post endpoint """
+
     url = url + '/retrobiohub/'
 
     test_data = [{"substrates": ["CC(N)c1ccccc1"],
@@ -12,15 +14,30 @@ def test_retrobiohub_endpoint(url):
                   }]
 
     response = requests.post(url, json=test_data)
-    return response
+    return json.loads(response.text)
+
+
+def test_minimongo_endpoint(url, db_id):
+    """ Test the /retrobiohub/minimongo get endpoint """
+
+    url = url + '/retrobiohub/minimongo/'
+
+    response = requests.post(url, json={'id': db_id})
+    return json.loads(response.text)
 
 
 # run flask app first, then try these tests
 if __name__ == '__main__':
     test_url = 'http://127.0.0.1:5000'
 
-    response = test_retrobiohub_endpoint(test_url)
-    print(response.text)
+    response_dict1 = test_retrobiohub_endpoint(test_url)
+    response_dict1 = json.loads(response_dict1)
+    print(response_dict1)
 
+    db_id = response_dict1['id']
+    print(db_id)
+
+    response_dict2 = test_minimongo_endpoint(test_url, db_id)
+    print(response_dict2)
 
 


### PR DESCRIPTION
I've created another test for the mini mongo endpoint.

And in the tests it gets the id from the response to the /retrobiohub/ post request.

A couple of notes/queries:

- To get the id from the response, I have to do json.loads twice, which seems a bit odd?  It works but is the response returned with an extra pair of "" or something?

- The minimongo endpoint isn't as documented in https://github.com/BioCatHub/bch_RetroBioHub/issues/12, which says it should be /rbh/.   Also the mini mongo endpoint is a post request rather than a get request.  I have no problem with this, just different from the meeting document.  It seems to work fine as a post request.  I haven't tested the liver version but I assume this is the same?